### PR TITLE
Make profile name evaluation case insensitive through constructor

### DIFF
--- a/ControllerCommon/ProfileManager.cs
+++ b/ControllerCommon/ProfileManager.cs
@@ -16,7 +16,7 @@ namespace ControllerCommon
             { true, 0x1e9df650 },
         };
 
-        public Dictionary<string, Profile> profiles = new Dictionary<string, Profile>();
+        public Dictionary<string, Profile> profiles = new Dictionary<string, Profile>(StringComparer.InvariantCultureIgnoreCase);
         public FileSystemWatcher profileWatcher { get; set; }
 
         public event DeletedEventHandler Deleted;


### PR DESCRIPTION
Fixed the issue of a profile name not matching the .exe RetroArch retroarch.

Made the profile dictionary ContainsKey case insenstive through constructor.

From stack overflow: https://stackoverflow.com/questions/13988643/case-insensitive-dictionary-with-string-key-type-in-c-sharp