### PR TITLE
prevent crash on system resume

### DIFF
--- a/ControllerService/ControllerService.cs
+++ b/ControllerService/ControllerService.cs
@@ -471,12 +471,8 @@ namespace ControllerService
                 case PowerModes.Resume:
                     // (re)initialize sensors
                     UpdateSensors();
-                    // (re)connect controller
-                    XInputController.virtualTarget.Connect();
                     break;
                 case PowerModes.Suspend:
-                    // disconnect controller
-                    XInputController.virtualTarget.Disconnect();
                     break;
             }
         }


### PR DESCRIPTION
disconnecting and reconnecting the virtual controller seams to crash Windows 11 on sleep and resume