### PR TITLE
Refactoring ILogger

### DIFF
--- a/ControllerCommon/ControllerCommon.csproj
+++ b/ControllerCommon/ControllerCommon.csproj
@@ -17,6 +17,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.2" />
@@ -24,6 +26,9 @@
     <PackageReference Include="Nefarius.ViGEm.Client" Version="1.17.178" />
     <PackageReference Include="NetCoreNamedPipeWrapper" Version="1.0.4" />
     <PackageReference Include="PInvoke.Kernel32" Version="0.7.104" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="SharpDX" Version="4.2.0" />
     <PackageReference Include="SharpDX.DirectInput" Version="4.2.0" />

--- a/ControllerCommon/ControllerEx.cs
+++ b/ControllerCommon/ControllerEx.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
-using Nefarius.Utilities.DeviceManagement.PnP;
+﻿using Nefarius.Utilities.DeviceManagement.PnP;
 using PInvoke;
 using SharpDX.XInput;
 using System;
@@ -22,8 +21,6 @@ namespace ControllerCommon
 
     public class ControllerEx
     {
-        private ILogger logger;
-
         private PnPDeviceEx deviceEx;
         public Controller Controller;
         public string Manufacturer, DeviceDesc;
@@ -54,10 +51,8 @@ namespace ControllerCommon
 
         private readonly Guid hidClassInterfaceGuid;
 
-        public ControllerEx(UserIndex index, ILogger logger)
+        public ControllerEx(UserIndex index)
         {
-            this.logger = logger;
-
             this.Controller = new Controller(index);
             this.UserIndex = index;
 
@@ -75,7 +70,7 @@ namespace ControllerCommon
             }
         }
 
-        public ControllerEx(UserIndex index, ILogger logger, ref List<PnPDeviceEx> devices) : this(index, logger)
+        public ControllerEx(UserIndex index, ref List<PnPDeviceEx> devices) : this(index)
         {
             if (ProductId is null || VendorId is null)
                 return;

--- a/ControllerCommon/FlickStick.cs
+++ b/ControllerCommon/FlickStick.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
-using System;
+﻿using System;
 using System.Numerics;
 using static ControllerCommon.Utils.CommonUtils;
 
@@ -25,11 +24,8 @@ namespace ControllerCommon
         private float FlickTime = 0.1f;
         private float FlickTimePartial = 0.01f;
 
-        private readonly ILogger logger;
-
-        public FlickStick(ILogger logger)
+        public FlickStick()
         {
-            this.logger = logger;
         }
 
         // Flick stick, flick to initial angle, allow for stick rotation in horizontal plane after

--- a/ControllerCommon/HidHide.cs
+++ b/ControllerCommon/HidHide.cs
@@ -1,5 +1,5 @@
-﻿using ControllerCommon.Utils;
-using Microsoft.Extensions.Logging;
+﻿using ControllerCommon.Managers;
+using ControllerCommon.Utils;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -11,17 +11,14 @@ namespace ControllerCommon
     {
         private Process process;
 
-        private readonly ILogger logger;
         private readonly string path = @"C:\Program Files\Nefarius Software Solutions e.U\HidHideCLI\HidHideCLI.exe";
 
-        public HidHide(ILogger logger)
+        public HidHide()
         {
-            this.logger = logger;
-
             // verifying HidHide is installed
             if (!File.Exists(path))
             {
-                logger.LogCritical("HidHide is missing. Please get it from: {0}", "https://github.com/ViGEm/HidHide/releases");
+                LogManager.LogCritical("HidHide is missing. Please get it from: {0}", "https://github.com/ViGEm/HidHide/releases");
                 throw new InvalidOperationException();
             }
 
@@ -134,12 +131,12 @@ namespace ControllerCommon
             process.WaitForExit();
             process.StandardOutput.ReadToEnd();
 
-            logger.LogInformation("{0} cloak status set to {1}", ProductName, status);
+            LogManager.LogInformation("{0} cloak status set to {1}", ProductName, status);
         }
 
         public void UnregisterController(string deviceInstancePath)
         {
-            logger.LogInformation("HideDevice unhiding DeviceID: {0}", deviceInstancePath);
+            LogManager.LogInformation("HideDevice unhiding DeviceID: {0}", deviceInstancePath);
             process.StartInfo.Arguments = $"--dev-unhide \"{deviceInstancePath}\"";
             process.Start();
             process.WaitForExit();
@@ -148,7 +145,7 @@ namespace ControllerCommon
 
         public void RegisterController(string deviceInstancePath)
         {
-            logger.LogInformation("HideDevice hiding DeviceID: {0}", deviceInstancePath);
+            LogManager.LogInformation("HideDevice hiding DeviceID: {0}", deviceInstancePath);
             process.StartInfo.Arguments = $"--dev-hide \"{deviceInstancePath}\"";
             process.Start();
             process.WaitForExit();

--- a/ControllerCommon/Managers/LogManager.cs
+++ b/ControllerCommon/Managers/LogManager.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Serilog;
+using Serilog.Extensions.Logging;
+using ILogger = Microsoft.Extensions.Logging.ILogger;
+
+namespace ControllerCommon.Managers
+{
+    public static class LogManager
+    {
+        private static ILogger logger;
+        public static void Initialize(string name)
+        {
+            var configuration = new ConfigurationBuilder()
+                        .AddJsonFile($"{name}.json")
+                        .Build();
+
+            var serilogLogger = new LoggerConfiguration()
+                .ReadFrom.Configuration(configuration)
+                .CreateLogger();
+
+            logger = new SerilogLoggerFactory(serilogLogger).CreateLogger(name);
+        }
+
+        public static void LogInformation(string message, params object[] args)
+        {
+            logger.LogInformation(message, args);
+        }
+        public static void LogWarning(string message, params object[] args)
+        {
+            logger.LogWarning(message, args);
+        }
+        public static void LogCritical(string message, params object[] args)
+        {
+            logger.LogCritical(message, args);
+        }
+        public static void LogDebug(string message, params object[] args)
+        {
+            logger.LogDebug(message, args);
+        }
+        public static void LogError(string message, params object[] args)
+        {
+            logger.LogError(message, args);
+        }
+    }
+}

--- a/ControllerCommon/Managers/ProfileManager.cs
+++ b/ControllerCommon/Managers/ProfileManager.cs
@@ -1,6 +1,5 @@
 ﻿using ControllerCommon.Utils;
 using Force.Crc32;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -33,12 +32,10 @@ namespace ControllerCommon.Managers
 
         public PipeClient PipeClient;
 
-        private readonly ILogger logger;
         private string path;
 
-        public ProfileManager(ILogger logger, PipeClient PipeClient = null)
+        public ProfileManager(PipeClient PipeClient = null)
         {
-            this.logger = logger;
             this.PipeClient = PipeClient;
         }
 
@@ -152,13 +149,13 @@ namespace ControllerCommon.Managers
             }
             catch (Exception ex)
             {
-                logger.LogError("Could not parse {0}. {1}", fileName, ex.Message);
+                LogManager.LogError("Could not parse {0}. {1}", fileName, ex.Message);
             }
 
             // failed to parse
             if (profile == null || profile.name == null || profile.path == null)
             {
-                logger.LogError("Could not parse {0}.", fileName);
+                LogManager.LogError("Could not parse {0}.", fileName);
                 return;
             }
 
@@ -177,7 +174,7 @@ namespace ControllerCommon.Managers
                 UnregisterApplication(profile);
                 profiles.Remove(profile.name);
                 Deleted?.Invoke(profile);
-                logger.LogInformation("Deleted profile {0}", settingsPath);
+                LogManager.LogInformation("Deleted profile {0}", settingsPath);
             }
 
             File.Delete(settingsPath);
@@ -228,7 +225,7 @@ namespace ControllerCommon.Managers
 
             if (profile.error != ProfileErrorCode.None && !profile.isDefault)
             {
-                logger.LogError("Profile {0} returned error code {1}", profile.name, profile.error);
+                LogManager.LogError("Profile {0} returned error code {1}", profile.name, profile.error);
                 return;
             }
 

--- a/ControllerCommon/Managers/ServiceManager.cs
+++ b/ControllerCommon/Managers/ServiceManager.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.Logging;
 using System;
 using System.Diagnostics;
 using System.ServiceProcess;
@@ -38,8 +37,6 @@ namespace ControllerCommon.Managers
         private Timer MonitorTimer;
         private object updateLock = new();
 
-        private readonly ILogger logger;
-
         public event UpdatedEventHandler Updated;
         public delegate void UpdatedEventHandler(ServiceControllerStatus status, int mode);
 
@@ -49,10 +46,8 @@ namespace ControllerCommon.Managers
         public event StopFailedEventHandler StopFailed;
         public delegate void StopFailedEventHandler(ServiceControllerStatus status);
 
-        public ServiceManager(string name, string display, string description, ILogger logger)
+        public ServiceManager(string name, string display, string description)
         {
-            this.logger = logger;
-
             this.name = name;
             this.display = display;
             this.description = description;
@@ -108,7 +103,7 @@ namespace ControllerCommon.Managers
                 {
                     Updated?.Invoke(status, (int)type);
                     nextStatus = ServiceControllerStatus.None;
-                    logger.LogInformation("Controller Service status has changed to: {0}", status.ToString());
+                    LogManager.LogInformation("Controller Service status has changed to: {0}", status.ToString());
                 }
 
                 prevStatus = (int)status;
@@ -133,7 +128,7 @@ namespace ControllerCommon.Managers
             }
             catch (Exception ex)
             {
-                logger.LogError("Service manager returned error: {0}", ex.Message);
+                LogManager.LogError("Service manager returned error: {0}", ex.Message);
             }
         }
 
@@ -164,7 +159,7 @@ namespace ControllerCommon.Managers
                 catch (Exception ex)
                 {
                     await Task.Delay(2000);
-                    logger.LogError("Service manager returned error: {0}", ex.Message);
+                    LogManager.LogError("Service manager returned error: {0}", ex.Message);
                     StartTentative++;
 
                     // exit loop
@@ -200,7 +195,7 @@ namespace ControllerCommon.Managers
                 catch (Exception ex)
                 {
                     await Task.Delay(2000);
-                    logger.LogError("Service manager returned error: {0}", ex.Message);
+                    LogManager.LogError("Service manager returned error: {0}", ex.Message);
                     StopTentative++;
 
                     // exit loop

--- a/ControllerCommon/Managers/SystemManager.cs
+++ b/ControllerCommon/Managers/SystemManager.cs
@@ -1,6 +1,5 @@
 ﻿using ControllerCommon.Sensors;
 using ControllerCommon.Utils;
-using Microsoft.Extensions.Logging;
 using Nefarius.Utilities.DeviceManagement.PnP;
 using System;
 using System.Collections.Generic;
@@ -14,8 +13,6 @@ namespace ControllerCommon.Managers
         [DllImport("hid.dll", EntryPoint = "HidD_GetHidGuid")]
         static internal extern void HidD_GetHidGuidMethod(out Guid hidGuid);
         #endregion
-
-        private ILogger logger;
 
         public static Guid HidDevice;
         private DeviceNotificationListener hidListener;
@@ -33,10 +30,8 @@ namespace ControllerCommon.Managers
         public event SerialRemovedEventHandler SerialRemoved;
         public delegate void SerialRemovedEventHandler(PnPDevice device);
 
-        public SystemManager(ILogger logger)
+        public SystemManager()
         {
-            this.logger = logger;
-
             // initialize hid
             HidD_GetHidGuidMethod(out var interfaceGuid);
             HidDevice = interfaceGuid;

--- a/ControllerCommon/SensorFusion.cs
+++ b/ControllerCommon/SensorFusion.cs
@@ -1,8 +1,7 @@
-﻿using ControllerCommon.Utils;
-using Microsoft.Extensions.Logging;
+﻿using ControllerCommon.Managers;
+using ControllerCommon.Utils;
 using System;
 using System.Numerics;
-using System.Threading.Tasks;
 
 namespace ControllerCommon
 {
@@ -24,36 +23,29 @@ namespace ControllerCommon
         // Device Angle
         public Vector2 DeviceAngle;
 
-        private readonly ILogger logger;
-
-        public SensorFusion(ILogger logger)
+        public SensorFusion()
         {
-            this.logger = logger;
         }
 
         public void UpdateReport(double TotalMilliseconds, double DeltaSeconds, Vector3 AngularVelocity, Vector3 Acceleration)
         {
-            Task.Run(() =>
-            {
-                logger.LogTrace("Plot XInputSensorFusion_DeltaSeconds {0} {1}", TotalMilliseconds, DeltaSeconds);
+#if DEBUG
+            LogManager.LogDebug("Plot XInputSensorFusion_DeltaSeconds {0} {1}", TotalMilliseconds, DeltaSeconds);
 
-                logger.LogTrace("Plot XInputSensorFusion_AngularVelocityX {0} {1}", TotalMilliseconds, AngularVelocity.X);
-                logger.LogTrace("Plot XInputSensorFusion_AngularVelocityY {0} {1}", TotalMilliseconds, AngularVelocity.Y);
-                logger.LogTrace("Plot XInputSensorFusion_AngularVelocityZ {0} {1}", TotalMilliseconds, AngularVelocity.Z);
+            LogManager.LogDebug("Plot XInputSensorFusion_AngularVelocityX {0} {1}", TotalMilliseconds, AngularVelocity.X);
+            LogManager.LogDebug("Plot XInputSensorFusion_AngularVelocityY {0} {1}", TotalMilliseconds, AngularVelocity.Y);
+            LogManager.LogDebug("Plot XInputSensorFusion_AngularVelocityZ {0} {1}", TotalMilliseconds, AngularVelocity.Z);
 
-                logger.LogTrace("Plot XInputSensorFusion_AccelerationX {0} {1}", TotalMilliseconds, Acceleration.X);
-                logger.LogTrace("Plot XInputSensorFusion_AccelerationY {0} {1}", TotalMilliseconds, Acceleration.Y);
-                logger.LogTrace("Plot XInputSensorFusion_AccelerationZ {0} {1}", TotalMilliseconds, Acceleration.Z);
-            });
+            LogManager.LogDebug("Plot XInputSensorFusion_AccelerationX {0} {1}", TotalMilliseconds, Acceleration.X);
+            LogManager.LogDebug("Plot XInputSensorFusion_AccelerationY {0} {1}", TotalMilliseconds, Acceleration.Y);
+            LogManager.LogDebug("Plot XInputSensorFusion_AccelerationZ {0} {1}", TotalMilliseconds, Acceleration.Z);
+#endif
 
             // Check for empty inputs, prevent NaN computes
             Vector3 EmptyVector = new(0f, 0f, 0f);
 
             if (AngularVelocity.Equals(EmptyVector) || Acceleration.Equals(EmptyVector))
-            {
-                logger.LogTrace("Sensorfusion prevented from calculating with empty vectors.");
                 return;
-            }
 
             // Perform calculations 
             // Todo, kickstart gravity vector with = acceleration when calculation is either
@@ -89,12 +81,11 @@ namespace ControllerCommon
 
             GravityVectorSimple += Vector3.Multiply(0.02f, Vector3.Normalize(gravityDelta));
 
-            Task.Run(() =>
-            {
-                logger.LogTrace("Plot XInputSensorFusion_GravityVectorSimpleEndX {0} {1}", TotalMilliseconds, GravityVectorSimple.X);
-                logger.LogTrace("Plot XInputSensorFusion_GravityVectorSimpleEndY {0} {1}", TotalMilliseconds, GravityVectorSimple.Y);
-                logger.LogTrace("Plot XInputSensorFusion_GravityVectorSimpleEndZ {0} {1}", TotalMilliseconds, GravityVectorSimple.Z);
-            });
+#if DEBUG
+            LogManager.LogDebug("Plot XInputSensorFusion_GravityVectorSimpleEndX {0} {1}", TotalMilliseconds, GravityVectorSimple.X);
+            LogManager.LogDebug("Plot XInputSensorFusion_GravityVectorSimpleEndY {0} {1}", TotalMilliseconds, GravityVectorSimple.Y);
+            LogManager.LogDebug("Plot XInputSensorFusion_GravityVectorSimpleEndZ {0} {1}", TotalMilliseconds, GravityVectorSimple.Z);
+#endif
         }
 
         public void CalculateGravityFancy(double TotalMilliseconds, double DeltaTimeSec, Vector3 AngularVelocity, Vector3 Acceleration)
@@ -137,13 +128,12 @@ namespace ControllerCommon
             // convert gyro input to reverse rotation  
             Quaternion reverseRotation = Quaternion.CreateFromAxisAngle(-AngularVelocityRad, AngularVelocityRad.Length() * (float)DeltaTimeSec);
 
-            Task.Run(() =>
-            {
-                logger.LogTrace("Plot vigemtarget_reverseRotationy.X {0} {1}", TotalMilliseconds, reverseRotation.X);
-                logger.LogTrace("Plot vigemtarget_reverseRotationy.Y {0} {1}", TotalMilliseconds, reverseRotation.Y);
-                logger.LogTrace("Plot vigemtarget_reverseRotationy.Z {0} {1}", TotalMilliseconds, reverseRotation.Z);
-                logger.LogTrace("Plot vigemtarget_reverseRotationy.W {0} {1}", TotalMilliseconds, reverseRotation.W);
-            });
+#if DEBUG
+            LogManager.LogDebug("Plot vigemtarget_reverseRotationy.X {0} {1}", TotalMilliseconds, reverseRotation.X);
+            LogManager.LogDebug("Plot vigemtarget_reverseRotationy.Y {0} {1}", TotalMilliseconds, reverseRotation.Y);
+            LogManager.LogDebug("Plot vigemtarget_reverseRotationy.Z {0} {1}", TotalMilliseconds, reverseRotation.Z);
+            LogManager.LogDebug("Plot vigemtarget_reverseRotationy.W {0} {1}", TotalMilliseconds, reverseRotation.W);
+#endif
 
             // rotate gravity vector
             GravityVectorFancy = Vector3.Transform(GravityVectorFancy, reverseRotation);
@@ -151,16 +141,15 @@ namespace ControllerCommon
             // Correction factor variables
             SmoothAccel = Vector3.Transform(SmoothAccel, reverseRotation);
 
-            Task.Run(() =>
-            {
-                logger.LogTrace("Plot vigemtarget_GravityVectorFancy_after_rotate_x {0} {1}", TotalMilliseconds, GravityVectorFancy.X);
-                logger.LogTrace("Plot vigemtarget_GravityVectorFancy_after_rotate_y {0} {1}", TotalMilliseconds, GravityVectorFancy.Y);
-                logger.LogTrace("Plot vigemtarget_GravityVectorFancy_after_rotate_z {0} {1}", TotalMilliseconds, GravityVectorFancy.Z);
+#if DEBUG
+            LogManager.LogDebug("Plot vigemtarget_GravityVectorFancy_after_rotate_x {0} {1}", TotalMilliseconds, GravityVectorFancy.X);
+            LogManager.LogDebug("Plot vigemtarget_GravityVectorFancy_after_rotate_y {0} {1}", TotalMilliseconds, GravityVectorFancy.Y);
+            LogManager.LogDebug("Plot vigemtarget_GravityVectorFancy_after_rotate_z {0} {1}", TotalMilliseconds, GravityVectorFancy.Z);
 
-                logger.LogTrace("Plot vigemtarget_GravityVectorFancy_SmoothAccel_x {0} {1}", TotalMilliseconds, SmoothAccel.X);
-                logger.LogTrace("Plot vigemtarget_GravityVectorFancy_SmoothAccel_y {0} {1}", TotalMilliseconds, SmoothAccel.Y);
-                logger.LogTrace("Plot vigemtarget_GravityVectorFancy_SmoothAccel_z {0} {1}", TotalMilliseconds, SmoothAccel.Z);
-            });
+            LogManager.LogDebug("Plot vigemtarget_GravityVectorFancy_SmoothAccel_x {0} {1}", TotalMilliseconds, SmoothAccel.X);
+            LogManager.LogDebug("Plot vigemtarget_GravityVectorFancy_SmoothAccel_y {0} {1}", TotalMilliseconds, SmoothAccel.Y);
+            LogManager.LogDebug("Plot vigemtarget_GravityVectorFancy_SmoothAccel_z {0} {1}", TotalMilliseconds, SmoothAccel.Z);
+#endif
 
             // Note to self, SmoothAccel seems OK.
             float smoothInterpolator = (float)Math.Pow(2, (-(float)DeltaTimeSec / SmoothingHalfTime));
@@ -170,16 +159,15 @@ namespace ControllerCommon
             Shakiness = Math.Max(Shakiness, Vector3.Subtract(Acceleration, SmoothAccel).Length()); // Does this apply vector subtract and length correctly?
             SmoothAccel = Vector3.Lerp(Acceleration, SmoothAccel, smoothInterpolator); // smoothInterpolator is a negative value, correct?
 
-            Task.Run(() =>
-            {
-                logger.LogTrace("Plot vigemtarget_GravityVectorFancy_smoothInterpolator {0} {1}", TotalMilliseconds, smoothInterpolator);
-                logger.LogTrace("Plot vigemtarget_GravityVectorFancy_ShakinessTimesInterpolator {0} {1}", TotalMilliseconds, Shakiness);
-                logger.LogTrace("Plot vigemtarget_GravityVectorFancy_Shakiness {0} {1}", TotalMilliseconds, Shakiness);
+#if DEBUG
+            LogManager.LogDebug("Plot vigemtarget_GravityVectorFancy_smoothInterpolator {0} {1}", TotalMilliseconds, smoothInterpolator);
+            LogManager.LogDebug("Plot vigemtarget_GravityVectorFancy_ShakinessTimesInterpolator {0} {1}", TotalMilliseconds, Shakiness);
+            LogManager.LogDebug("Plot vigemtarget_GravityVectorFancy_Shakiness {0} {1}", TotalMilliseconds, Shakiness);
 
-                logger.LogTrace("Plot vigemtarget_GravityVectorFancy_SmoothAccel2_x {0} {1}", TotalMilliseconds, SmoothAccel.X);
-                logger.LogTrace("Plot vigemtarget_GravityVectorFancy_SmoothAccel2_y {0} {1}", TotalMilliseconds, SmoothAccel.Y);
-                logger.LogTrace("Plot vigemtarget_GravityVectorFancy_SmoothAccel2_z {0} {1}", TotalMilliseconds, SmoothAccel.Z);
-            });
+            LogManager.LogDebug("Plot vigemtarget_GravityVectorFancy_SmoothAccel2_x {0} {1}", TotalMilliseconds, SmoothAccel.X);
+            LogManager.LogDebug("Plot vigemtarget_GravityVectorFancy_SmoothAccel2_y {0} {1}", TotalMilliseconds, SmoothAccel.Y);
+            LogManager.LogDebug("Plot vigemtarget_GravityVectorFancy_SmoothAccel2_z {0} {1}", TotalMilliseconds, SmoothAccel.Z);
+#endif
 
             Vector3 gravityDelta = Vector3.Subtract(-Acceleration, GravityVectorFancy);
             Vector3 gravityDirection = Vector3.Normalize(gravityDelta);
@@ -190,10 +178,9 @@ namespace ControllerCommon
             {
                 float stillOrShaky = Math.Clamp((Shakiness - ShakinessMinThreshold) / (ShakinessMaxThreshold - ShakinessMaxThreshold), 0, 1);
 
-                Task.Run(() =>
-                {
-                    logger.LogTrace("Plot vigemtarget_GravityVectorFancy_stillOrShaky {0} {1}", TotalMilliseconds, stillOrShaky);
-                });
+#if DEBUG
+                LogManager.LogDebug("Plot vigemtarget_GravityVectorFancy_stillOrShaky {0} {1}", TotalMilliseconds, stillOrShaky);
+#endif
 
                 correctionRate = CorrectionStillRate + (CorrectionShakyRate - CorrectionStillRate) * stillOrShaky;
                 // 1 + (0.1 - 1) * 1 = 0.1
@@ -214,13 +201,12 @@ namespace ControllerCommon
             float angleRate = AngularVelocity.Length() * (float)Math.PI / 180;
             float correctionLimit = angleRate * GravityVectorFancy.Length() * CorrectionGyroFactor;
 
-            Task.Run(() =>
-            {
-                logger.LogTrace("Plot vigemtarget_GravityVectorFancy_correctionRate {0} {1}", TotalMilliseconds, correctionRate);
+#if DEBUG
+            LogManager.LogDebug("Plot vigemtarget_GravityVectorFancy_correctionRate {0} {1}", TotalMilliseconds, correctionRate);
 
-                logger.LogTrace("Plot vigemtarget_GravityVectorFancy_angleRate {0} {1}", TotalMilliseconds, angleRate);
-                logger.LogTrace("Plot vigemtarget_GravityVectorFancy_correctionLimit {0} {1}", TotalMilliseconds, correctionLimit);
-            });
+            LogManager.LogDebug("Plot vigemtarget_GravityVectorFancy_angleRate {0} {1}", TotalMilliseconds, angleRate);
+            LogManager.LogDebug("Plot vigemtarget_GravityVectorFancy_correctionLimit {0} {1}", TotalMilliseconds, correctionLimit);
+#endif
 
             if (correctionRate > correctionLimit)
             {
@@ -279,11 +265,10 @@ namespace ControllerCommon
             // Pitch (local space)
             CameraPitchDelta = AngularVelocity.X * AdditionalFactor * DeltaSeconds;
 
-            Task.Run(() =>
-            {
-                logger.LogTrace("Plot XInputSensorFusion_CameraYawDelta {0} {1}", TotalMilliseconds, CameraYawDelta);
-                logger.LogTrace("Plot XInputSensorFusion_CameraPitchDelta {0} {1}", TotalMilliseconds, CameraPitchDelta);
-            });
+#if DEBUG
+            LogManager.LogDebug("Plot XInputSensorFusion_CameraYawDelta {0} {1}", TotalMilliseconds, CameraYawDelta);
+            LogManager.LogDebug("Plot XInputSensorFusion_CameraPitchDelta {0} {1}", TotalMilliseconds, CameraPitchDelta);
+#endif
         }
 
         private void DeviceAngles(double TotalMilliseconds, Vector3 GravityVector)
@@ -294,10 +279,9 @@ namespace ControllerCommon
             DeviceAngle.X = (float)((Math.Atan(GravityVector.Y / (Math.Sqrt(Math.Pow(GravityVector.X, 2) + Math.Pow(GravityVector.Z, 2))))) * 180 / Math.PI);
             DeviceAngle.Y = (float)((Math.Atan(GravityVector.X / (Math.Sqrt(Math.Pow(GravityVector.Y, 2) + Math.Pow(GravityVector.Z, 2))))) * 180 / Math.PI);
 
-            Task.Run(() =>
-            {
-                logger.LogTrace("Plot XInputSensorFusion_DeviceAngle.Y {0} {1}", TotalMilliseconds, DeviceAngle.Y);
-            });
+#if DEBUG
+            LogManager.LogDebug("Plot XInputSensorFusion_DeviceAngle.Y {0} {1}", TotalMilliseconds, DeviceAngle.Y);
+#endif
         }
     }
 }

--- a/ControllerService/DSUServer.cs
+++ b/ControllerService/DSUServer.cs
@@ -1,7 +1,7 @@
+using ControllerCommon.Managers;
 using ControllerCommon.Utils;
 using ControllerService.Sensors;
 using Force.Crc32;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -99,7 +99,6 @@ namespace ControllerService
             meta = padMeta;
         }
 
-        private readonly ILogger logger;
         public string ip;
         public int port;
         private Vector3 empty = new();
@@ -110,9 +109,8 @@ namespace ControllerService
         public event StoppedEventHandler Stopped;
         public delegate void StoppedEventHandler(DSUServer server);
 
-        public DSUServer(string ipString, int port, ILogger logger)
+        public DSUServer(string ipString, int port)
         {
-            this.logger = logger;
             this.ip = ipString;
             this.port = port;
 
@@ -512,7 +510,7 @@ namespace ControllerService
             }
             catch (SocketException)
             {
-                logger.LogCritical("{0} couldn't listen to ip: {1} port: {2}", this.ToString(), ip, port);
+                LogManager.LogCritical("{0} couldn't listen to ip: {1} port: {2}", this.ToString(), ip, port);
                 this.Stop();
                 return running;
             }
@@ -527,7 +525,7 @@ namespace ControllerService
             BatteryTimer.Enabled = true;
             BatteryTimer.Start();
 
-            logger.LogInformation("{0} has started. Listening to ip: {1} port: {2}", this.ToString(), ip, port);
+            LogManager.LogInformation("{0} has started. Listening to ip: {1} port: {2}", this.ToString(), ip, port);
             Started?.Invoke(this);
 
             return running;
@@ -542,7 +540,7 @@ namespace ControllerService
             }
             running = false;
 
-            logger.LogInformation($"{0} has stopped", this.ToString());
+            LogManager.LogInformation($"{0} has stopped", this.ToString());
             Stopped?.Invoke(this);
         }
 

--- a/ControllerService/Program.cs
+++ b/ControllerService/Program.cs
@@ -1,9 +1,7 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using ControllerCommon.Managers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Serilog;
-using Serilog.Core;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -12,26 +10,19 @@ namespace ControllerService
 {
     internal static class Program
     {
-        private static Logger logger;
-
         public static void Main(string[] args)
         {
             Directory.SetCurrentDirectory(AppDomain.CurrentDomain.BaseDirectory);
 
-            var configuration = new ConfigurationBuilder()
-                        .AddJsonFile("ControllerService.json")
-                        .Build();
-
-            logger = new LoggerConfiguration()
-                .ReadFrom.Configuration(configuration)
-                .CreateLogger();
+            // initialize log manager
+            LogManager.Initialize("ControllerService");
 
             string proc = Process.GetCurrentProcess().ProcessName;
             Process[] processes = Process.GetProcessesByName(proc);
 
             if (processes.Length > 1)
             {
-                logger.Fatal("{0} is already running. Exiting.", proc);
+                LogManager.LogCritical("{0} is already running. Exiting.", proc);
                 return;
             }
 
@@ -47,10 +38,7 @@ namespace ControllerService
                     services.AddLogging(builder =>
                     {
                         builder.SetMinimumLevel(LogLevel.Information);
-                        builder.AddSerilog(logger, true);
                     });
-
-                    services.AddSingleton(new LoggerFactory().AddSerilog(logger));
 
                     services.AddHostedService<ControllerService>();
                 });

--- a/ControllerService/Sensors/XInputAccelerometer.cs
+++ b/ControllerService/Sensors/XInputAccelerometer.cs
@@ -1,6 +1,6 @@
+using ControllerCommon.Managers;
 using ControllerCommon.Sensors;
 using ControllerCommon.Utils;
-using Microsoft.Extensions.Logging;
 using System.Numerics;
 using Windows.Devices.Sensors;
 using static ControllerCommon.Utils.DeviceUtils;
@@ -17,7 +17,7 @@ namespace ControllerService.Sensors
             maxOut = short.MaxValue,
         };
 
-        public XInputAccelerometer(SensorFamily sensorFamily, int updateInterval, ILogger logger) : base(logger)
+        public XInputAccelerometer(SensorFamily sensorFamily, int updateInterval) : base()
         {
             this.updateInterval = updateInterval;
             UpdateSensor(sensorFamily);
@@ -31,13 +31,13 @@ namespace ControllerService.Sensors
                     sensor = Accelerometer.GetDefault();
                     break;
                 case SensorFamily.SerialUSBIMU:
-                    sensor = SerialUSBIMU.GetDefault(logger);
+                    sensor = SerialUSBIMU.GetDefault();
                     break;
             }
 
             if (sensor == null)
             {
-                logger.LogWarning("{0} not initialised as a {1}.", this.ToString(), sensorFamily.ToString());
+                LogManager.LogWarning("{0} not initialised as a {1}.", this.ToString(), sensorFamily.ToString());
                 return;
             }
 
@@ -48,13 +48,13 @@ namespace ControllerService.Sensors
                     ((Accelerometer)sensor).ReadingChanged += ReadingChanged;
                     filter.SetFilterAttrs(ControllerService.handheldDevice.oneEuroSettings.minCutoff, ControllerService.handheldDevice.oneEuroSettings.beta);
 
-                    logger.LogInformation("{0} initialised as a {1}. Report interval set to {2}ms", this.ToString(), sensorFamily.ToString(), updateInterval);
+                    LogManager.LogInformation("{0} initialised as a {1}. Report interval set to {2}ms", this.ToString(), sensorFamily.ToString(), updateInterval);
                     break;
                 case SensorFamily.SerialUSBIMU:
                     ((SerialUSBIMU)sensor).ReadingChanged += ReadingChanged;
                     filter.SetFilterAttrs(((SerialUSBIMU)sensor).GetFilterCutoff(), ((SerialUSBIMU)sensor).GetFilterBeta());
 
-                    logger.LogInformation("{0} initialised as a {1}. Baud rate set to {2}", this.ToString(), sensorFamily.ToString(), ((SerialUSBIMU)sensor).GetInterval());
+                    LogManager.LogInformation("{0} initialised as a {1}. Baud rate set to {2}", this.ToString(), sensorFamily.ToString(), ((SerialUSBIMU)sensor).GetInterval());
                     break;
             }
         }

--- a/ControllerService/Sensors/XInputGirometer.cs
+++ b/ControllerService/Sensors/XInputGirometer.cs
@@ -1,6 +1,6 @@
+using ControllerCommon.Managers;
 using ControllerCommon.Sensors;
 using ControllerCommon.Utils;
-using Microsoft.Extensions.Logging;
 using System.Numerics;
 using Windows.Devices.Sensors;
 using static ControllerCommon.Utils.DeviceUtils;
@@ -17,7 +17,7 @@ namespace ControllerService.Sensors
             maxOut = 2048.0f,
         };
 
-        public XInputGirometer(SensorFamily sensorFamily, int updateInterval, ILogger logger) : base(logger)
+        public XInputGirometer(SensorFamily sensorFamily, int updateInterval) : base()
         {
             this.updateInterval = updateInterval;
             centerTimer.Interval = updateInterval * 6;
@@ -33,13 +33,13 @@ namespace ControllerService.Sensors
                     sensor = Gyrometer.GetDefault();
                     break;
                 case SensorFamily.SerialUSBIMU:
-                    sensor = SerialUSBIMU.GetDefault(logger);
+                    sensor = SerialUSBIMU.GetDefault();
                     break;
             }
 
             if (sensor == null)
             {
-                logger.LogWarning("{0} not initialised as a {1}.", this.ToString(), sensorFamily.ToString());
+                LogManager.LogWarning("{0} not initialised as a {1}.", this.ToString(), sensorFamily.ToString());
                 return;
             }
 
@@ -49,12 +49,12 @@ namespace ControllerService.Sensors
                     ((Gyrometer)sensor).ReportInterval = (uint)updateInterval;
                     ((Gyrometer)sensor).ReadingChanged += ReadingChanged;
 
-                    logger.LogInformation("{0} initialised as a {1}. Report interval set to {2}ms", this.ToString(), sensorFamily.ToString(), updateInterval);
+                    LogManager.LogInformation("{0} initialised as a {1}. Report interval set to {2}ms", this.ToString(), sensorFamily.ToString(), updateInterval);
                     break;
                 case SensorFamily.SerialUSBIMU:
                     ((SerialUSBIMU)sensor).ReadingChanged += ReadingChanged;
 
-                    logger.LogInformation("{0} initialised as a {1}. Baud rate set to {2}", this.ToString(), sensorFamily.ToString(), ((SerialUSBIMU)sensor).GetInterval());
+                    LogManager.LogInformation("{0} initialised as a {1}. Baud rate set to {2}", this.ToString(), sensorFamily.ToString(), ((SerialUSBIMU)sensor).GetInterval());
                     break;
             }
         }

--- a/ControllerService/Sensors/XInputInclinometer.cs
+++ b/ControllerService/Sensors/XInputInclinometer.cs
@@ -1,5 +1,5 @@
+using ControllerCommon.Managers;
 using ControllerCommon.Sensors;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Numerics;
 using Windows.Devices.Sensors;
@@ -9,7 +9,7 @@ namespace ControllerService.Sensors
 {
     public class XInputInclinometer : XInputSensor
     {
-        public XInputInclinometer(SensorFamily sensorFamily, int updateInterval, ILogger logger) : base(logger)
+        public XInputInclinometer(SensorFamily sensorFamily, int updateInterval) : base()
         {
             this.updateInterval = updateInterval;
             UpdateSensor(sensorFamily);
@@ -23,13 +23,13 @@ namespace ControllerService.Sensors
                     sensor = Accelerometer.GetDefault();
                     break;
                 case SensorFamily.SerialUSBIMU:
-                    sensor = SerialUSBIMU.GetDefault(logger);
+                    sensor = SerialUSBIMU.GetDefault();
                     break;
             }
 
             if (sensor == null)
             {
-                logger.LogWarning("{0} not initialised as a {1}.", this.ToString(), sensorFamily.ToString());
+                LogManager.LogWarning("{0} not initialised as a {1}.", this.ToString(), sensorFamily.ToString());
                 return;
             }
 
@@ -40,13 +40,13 @@ namespace ControllerService.Sensors
                     ((Accelerometer)sensor).ReadingChanged += ReadingChanged;
                     filter.SetFilterAttrs(ControllerService.handheldDevice.oneEuroSettings.minCutoff, ControllerService.handheldDevice.oneEuroSettings.beta);
 
-                    logger.LogInformation("{0} initialised as a {1}. Report interval set to {2}ms", this.ToString(), sensorFamily.ToString(), updateInterval);
+                    LogManager.LogInformation("{0} initialised as a {1}. Report interval set to {2}ms", this.ToString(), sensorFamily.ToString(), updateInterval);
                     break;
                 case SensorFamily.SerialUSBIMU:
                     ((SerialUSBIMU)sensor).ReadingChanged += ReadingChanged;
                     filter.SetFilterAttrs(((SerialUSBIMU)sensor).GetFilterCutoff(), ((SerialUSBIMU)sensor).GetFilterBeta());
 
-                    logger.LogInformation("{0} initialised as a {1}. Baud rate set to {2}", this.ToString(), sensorFamily.ToString(), ((SerialUSBIMU)sensor).GetInterval());
+                    LogManager.LogInformation("{0} initialised as a {1}. Baud rate set to {2}", this.ToString(), sensorFamily.ToString(), ((SerialUSBIMU)sensor).GetInterval());
                     break;
             }
         }

--- a/ControllerService/Sensors/XInputSensor.cs
+++ b/ControllerService/Sensors/XInputSensor.cs
@@ -1,9 +1,8 @@
-﻿using ControllerCommon.Sensors;
+﻿using ControllerCommon.Managers;
+using ControllerCommon.Sensors;
 using ControllerCommon.Utils;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Numerics;
-using System.Threading.Tasks;
 using System.Timers;
 using Windows.Devices.Sensors;
 using static ControllerCommon.Utils.CommonUtils;
@@ -43,12 +42,8 @@ namespace ControllerService.Sensors
         public object sensor;
         public OneEuroFilter3D filter = new();
 
-        protected readonly ILogger logger;
-
-        protected XInputSensor(ILogger logger)
+        protected XInputSensor()
         {
-            this.logger = logger;
-
             this.centerTimer = new Timer() { Enabled = false, AutoReset = false, Interval = 100 };
             this.centerTimer.Elapsed += Timer_Elapsed;
         }
@@ -59,7 +54,9 @@ namespace ControllerService.Sensors
             centerTimer.Stop();
             centerTimer.Start();
 
-            Task.Run(() => logger?.LogTrace("{0}.ReadingChanged({1:00.####}, {2:00.####}, {3:00.####})", this.GetType().Name, this.reading.X, this.reading.Y, this.reading.Z));
+#if DEBUG
+            LogManager.LogDebug("{0}.ReadingChanged({1:00.####}, {2:00.####}, {3:00.####})", this.GetType().Name, this.reading.X, this.reading.Y, this.reading.Z);
+#endif
         }
 
         public static XInputSensorStatus GetStatus(SensorFamily sensorFamily)

--- a/ControllerService/Targets/DualShock4Target.cs
+++ b/ControllerService/Targets/DualShock4Target.cs
@@ -1,6 +1,5 @@
 ﻿using ControllerCommon.Utils;
 using ControllerService.Sensors;
-using Microsoft.Extensions.Logging;
 using Nefarius.ViGEm.Client;
 using Nefarius.ViGEm.Client.Exceptions;
 using Nefarius.ViGEm.Client.Targets;
@@ -49,7 +48,7 @@ namespace ControllerService.Targets
 
         private new IDualShock4Controller virtualController;
 
-        public DualShock4Target(XInputController xinput, ViGEmClient client, ILogger logger) : base(xinput, client, logger)
+        public DualShock4Target(XInputController xinput, ViGEmClient client) : base(xinput, client)
         {
             // initialize controller
             HID = HIDmode.DualShock4Controller;
@@ -219,7 +218,7 @@ namespace ControllerService.Targets
             {
                 virtualController.SubmitRawReport(rawOutReportEx);
             }
-            catch(VigemBusNotFoundException)
+            catch (VigemBusNotFoundException)
             {
                 // todo: prevent this from happening !
             }

--- a/ControllerService/Targets/ViGEmTarget.cs
+++ b/ControllerService/Targets/ViGEmTarget.cs
@@ -1,7 +1,7 @@
 using ControllerCommon;
+using ControllerCommon.Managers;
 using ControllerCommon.Utils;
 using ControllerService.Sensors;
-using Microsoft.Extensions.Logging;
 using Nefarius.ViGEm.Client;
 using SharpDX.XInput;
 using System;
@@ -39,8 +39,6 @@ namespace ControllerService.Targets
 
         public HIDmode HID = HIDmode.NoController;
 
-        protected readonly ILogger logger;
-
         protected ViGEmClient client { get; }
         protected IVirtualGamepad virtualController;
 
@@ -59,12 +57,10 @@ namespace ControllerService.Targets
 
         protected bool IsConnected;
 
-        protected ViGEmTarget(XInputController xinput, ViGEmClient client, ILogger logger)
+        protected ViGEmTarget(XInputController xinput, ViGEmClient client)
         {
-            this.logger = logger;
-
             // initialize flick stick
-            flickStick = new FlickStick(logger);
+            flickStick = new FlickStick();
 
             // initialize secret state
             state_s = new();
@@ -82,7 +78,7 @@ namespace ControllerService.Targets
         public void SetVibrationStrength(double strength)
         {
             vibrationStrength = strength / 100.0f;
-            logger.LogInformation("{0} vibration strength set to {1}%", this, strength);
+            LogManager.LogInformation("{0} vibration strength set to {1}%", this, strength);
         }
 
         public override string ToString()
@@ -94,14 +90,14 @@ namespace ControllerService.Targets
         {
             IsConnected = true;
             Connected?.Invoke(this);
-            logger.LogInformation("{0} connected", ToString());
+            LogManager.LogInformation("{0} connected", ToString());
         }
 
         public virtual void Disconnect()
         {
             IsConnected = false;
             Disconnected?.Invoke(this);
-            logger.LogInformation("{0} disconnected", ToString());
+            LogManager.LogInformation("{0} disconnected", ToString());
         }
 
 

--- a/ControllerService/Targets/Xbox360Target.cs
+++ b/ControllerService/Targets/Xbox360Target.cs
@@ -1,5 +1,4 @@
 ﻿using ControllerCommon.Utils;
-using Microsoft.Extensions.Logging;
 using Nefarius.ViGEm.Client;
 using Nefarius.ViGEm.Client.Exceptions;
 using Nefarius.ViGEm.Client.Targets;
@@ -47,7 +46,7 @@ namespace ControllerService.Targets
 
         private new IXbox360Controller virtualController;
 
-        public Xbox360Target(XInputController xinput, ViGEmClient client, ILogger logger) : base(xinput, client, logger)
+        public Xbox360Target(XInputController xinput, ViGEmClient client) : base(xinput, client)
         {
             // initialize controller
             HID = HIDmode.Xbox360Controller;

--- a/HandheldCompanion/App.xaml.cs
+++ b/HandheldCompanion/App.xaml.cs
@@ -1,8 +1,6 @@
 ﻿using ControllerCommon;
+using ControllerCommon.Managers;
 using HandheldCompanion.Views;
-using Microsoft.Extensions.Configuration;
-using Serilog;
-using Serilog.Extensions.Logging;
 using System;
 using System.Globalization;
 using System.IO;
@@ -48,17 +46,10 @@ namespace HandheldCompanion
             {
                 Directory.SetCurrentDirectory(AppDomain.CurrentDomain.BaseDirectory);
 
-                var configuration = new ConfigurationBuilder()
-                            .AddJsonFile("HandheldCompanion.json")
-                            .Build();
+                // initialize log manager
+                LogManager.Initialize("HandheldCompanion");
 
-                var serilogLogger = new LoggerConfiguration()
-                    .ReadFrom.Configuration(configuration)
-                    .CreateLogger();
-
-                var logger = new SerilogLoggerFactory(serilogLogger).CreateLogger("HandheldCompanion");
-
-                MainWindow wnd = new MainWindow(Arguments, logger);
+                MainWindow wnd = new MainWindow(Arguments);
                 wnd.Show();
 
                 mutex.ReleaseMutex();

--- a/HandheldCompanion/CmdParser.cs
+++ b/HandheldCompanion/CmdParser.cs
@@ -1,8 +1,8 @@
 ﻿using CommandLine;
 using ControllerCommon;
+using ControllerCommon.Managers;
 using ControllerCommon.Utils;
 using HandheldCompanion.Views;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -15,13 +15,10 @@ namespace HandheldCompanion
         private readonly PipeClient pipeClient;
         private readonly MainWindow mainWindow;
 
-        private readonly ILogger logger;
-
-        public CmdParser(PipeClient pipeClient, MainWindow mainWindow, ILogger logger)
+        public CmdParser(PipeClient pipeClient, MainWindow mainWindow)
         {
             this.pipeClient = pipeClient;
             this.mainWindow = mainWindow;
-            this.logger = logger;
         }
 
         public void ParseArgs(string[] args, bool init = false)
@@ -29,7 +26,7 @@ namespace HandheldCompanion
             if (args.Length == 0)
                 return;
 
-            logger?.LogInformation("Parsing command: {0}", String.Join(' ', args));
+            LogManager.LogInformation("Parsing command: {0}", String.Join(' ', args));
 
             Parser.Default.ParseArguments<ProfileOption, ProfileService, DeviceOption>(args)
                 .MapResult(
@@ -111,7 +108,7 @@ namespace HandheldCompanion
 
         private bool CmdError(IEnumerable<Error> errors)
         {
-            logger?.LogError("Couldn't parse command. Errors: {0}", String.Join(", ", errors));
+            LogManager.LogError("Couldn't parse command. Errors: {0}", String.Join(", ", errors));
             return true;
         }
 

--- a/HandheldCompanion/Managers/CheatManager.cs
+++ b/HandheldCompanion/Managers/CheatManager.cs
@@ -1,11 +1,8 @@
 ﻿using ControllerCommon;
-using Microsoft.Extensions.Logging;
 using SharpDX.XInput;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace HandheldCompanion.Managers
 {
@@ -18,15 +15,11 @@ namespace HandheldCompanion.Managers
         private Gamepad prevGamepad;
         private State GamepadState;
 
-        private ILogger logger;
-
         public event CheatedEventHandler Cheated;
         public delegate void CheatedEventHandler(string cheat);
 
-        public CheatManager(ILogger logger)
+        public CheatManager()
         {
-            this.logger = logger;
-
             // initialize timers
             UpdateTimer = new MultimediaTimer(10);
         }

--- a/HandheldCompanion/Managers/ControllerManager.cs
+++ b/HandheldCompanion/Managers/ControllerManager.cs
@@ -1,6 +1,5 @@
 ﻿using ControllerCommon;
 using ControllerCommon.Managers;
-using Microsoft.Extensions.Logging;
 using SharpDX.XInput;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,8 +8,6 @@ namespace HandheldCompanion.Managers
 {
     public class ControllerManager
     {
-        private ILogger logger;
-
         private SystemManager systemManager;
 
         private Dictionary<string, ControllerEx> controllers;
@@ -22,13 +19,12 @@ namespace HandheldCompanion.Managers
         public event ControllerUnpluggedEventHandler ControllerUnplugged;
         public delegate void ControllerUnpluggedEventHandler(ControllerEx controller);
 
-        public ControllerManager(ILogger logger)
+        public ControllerManager()
         {
-            this.logger = logger;
             controllers = new();
 
             // initialize manager(s)
-            systemManager = new SystemManager(logger);
+            systemManager = new SystemManager();
             systemManager.XInputArrived += SystemManager_XInputUpdated;
             systemManager.XInputRemoved += SystemManager_XInputUpdated;
         }
@@ -52,7 +48,7 @@ namespace HandheldCompanion.Managers
                 for (int idx = 0; idx < 4; idx++)
                 {
                     UserIndex userIndex = (UserIndex)idx;
-                    ControllerEx controllerEx = new ControllerEx(userIndex, null, ref devices);
+                    ControllerEx controllerEx = new ControllerEx(userIndex, ref devices);
 
                     controllers[controllerEx.baseContainerDeviceInstancePath] = controllerEx;
 
@@ -90,7 +86,7 @@ namespace HandheldCompanion.Managers
                 for (int idx = 0; idx < 4; idx++)
                 {
                     UserIndex userIndex = (UserIndex)idx;
-                    ControllerEx controllerEx = new ControllerEx(userIndex, null, ref devices);
+                    ControllerEx controllerEx = new ControllerEx(userIndex, ref devices);
 
                     controllers[controllerEx.baseContainerDeviceInstancePath] = controllerEx;
 

--- a/HandheldCompanion/Managers/UpdateManager.cs
+++ b/HandheldCompanion/Managers/UpdateManager.cs
@@ -3,7 +3,6 @@ using ModernWpf.Controls;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Net.Cache;

--- a/HandheldCompanion/Models/Model.cs
+++ b/HandheldCompanion/Models/Model.cs
@@ -3,7 +3,6 @@ using SharpDX.XInput;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Windows.Media;
 using System.Windows.Media.Media3D;
 
 namespace HandheldCompanion

--- a/HandheldCompanion/Settings.cs
+++ b/HandheldCompanion/Settings.cs
@@ -1,14 +1,17 @@
-﻿namespace HandheldCompanion.Properties {
-    
-    
+﻿namespace HandheldCompanion.Properties
+{
+
+
     // This class allows you to handle specific events on the settings class:
     //  The SettingChanging event is raised before a setting's value is changed.
     //  The PropertyChanged event is raised after a setting's value is changed.
     //  The SettingsLoaded event is raised after the setting values are loaded.
     //  The SettingsSaving event is raised before the setting values are saved.
-    internal sealed partial class Settings {
-        
-        public Settings() {
+    internal sealed partial class Settings
+    {
+
+        public Settings()
+        {
             // // To add event handlers for saving and changing settings, uncomment the lines below:
             //
             // this.SettingChanging += this.SettingChangingEventHandler;
@@ -16,12 +19,14 @@
             // this.SettingsSaving += this.SettingsSavingEventHandler;
             //
         }
-        
-        private void SettingChangingEventHandler(object sender, System.Configuration.SettingChangingEventArgs e) {
+
+        private void SettingChangingEventHandler(object sender, System.Configuration.SettingChangingEventArgs e)
+        {
             // Add code to handle the SettingChangingEvent event here.
         }
-        
-        private void SettingsSavingEventHandler(object sender, System.ComponentModel.CancelEventArgs e) {
+
+        private void SettingsSavingEventHandler(object sender, System.ComponentModel.CancelEventArgs e)
+        {
             // Add code to handle the SettingsSaving event here.
         }
     }

--- a/HandheldCompanion/Views/Pages/AboutPage.xaml.cs
+++ b/HandheldCompanion/Views/Pages/AboutPage.xaml.cs
@@ -1,5 +1,4 @@
 using ControllerCommon;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Windows;
 using System.Windows.Controls;
@@ -14,7 +13,6 @@ namespace HandheldCompanion.Views.Pages
     public partial class AboutPage : Page
     {
         private MainWindow mainWindow;
-        private ILogger logger;
         private PipeClient pipeClient;
 
         public AboutPage()
@@ -22,11 +20,10 @@ namespace HandheldCompanion.Views.Pages
             InitializeComponent();
         }
 
-        public AboutPage(string Tag, MainWindow mainWindow, ILogger logger) : this()
+        public AboutPage(string Tag, MainWindow mainWindow) : this()
         {
             this.Tag = Tag;
             this.mainWindow = mainWindow;
-            this.logger = logger;
 
             this.pipeClient = mainWindow.pipeClient;
             this.pipeClient.ServerMessage += OnServerMessage;

--- a/HandheldCompanion/Views/Pages/ControllerPage.xaml.cs
+++ b/HandheldCompanion/Views/Pages/ControllerPage.xaml.cs
@@ -2,7 +2,6 @@ using ControllerCommon;
 using ControllerCommon.Managers;
 using ControllerCommon.Utils;
 using HandheldCompanion.Managers;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -26,7 +25,6 @@ namespace HandheldCompanion.Views.Pages
         private readonly HidHide Hidder;
         private readonly ToastManager toastManager;
 
-        private readonly ILogger logger;
         private ServiceManager serviceManager;
 
         // pipe vars
@@ -55,21 +53,19 @@ namespace HandheldCompanion.Views.Pages
                 cB_HidMode.Items.Add(EnumUtils.GetDescriptionFromEnumValue(mode));
 
             // initialize controller manager
-            controllerManager = new ControllerManager(logger);
+            controllerManager = new ControllerManager();
             controllerManager.ControllerPlugged += ControllerPlugged;
             controllerManager.ControllerUnplugged += ControllerUnplugged;
             controllerManager.StartListen();
         }
 
-        public ControllerPage(string Tag, MainWindow mainWindow, ILogger logger) : this()
+        public ControllerPage(string Tag, MainWindow mainWindow) : this()
         {
             this.Tag = Tag;
 
             this.mainWindow = mainWindow;
             this.Hidder = mainWindow.Hidder;
             this.toastManager = mainWindow.toastManager;
-
-            this.logger = logger;
 
             this.pipeClient = mainWindow.pipeClient;
             this.pipeClient.ServerMessage += OnServerMessage;

--- a/HandheldCompanion/Views/Pages/OverlayPage.xaml.cs
+++ b/HandheldCompanion/Views/Pages/OverlayPage.xaml.cs
@@ -1,7 +1,6 @@
 ﻿using ControllerCommon.Utils;
 using HandheldCompanion.Models;
 using HandheldCompanion.Views.Windows;
-using Microsoft.Extensions.Logging;
 using ModernWpf.Controls;
 using System.Windows;
 using System.Windows.Controls;
@@ -16,7 +15,6 @@ namespace HandheldCompanion.Views.Pages
     /// </summary>
     public partial class OverlayPage : Page
     {
-        private ILogger logger;
         private Overlay overlay;
         private bool Initialized;
 
@@ -26,14 +24,12 @@ namespace HandheldCompanion.Views.Pages
             Initialized = true;
         }
 
-        public OverlayPage(string Tag, Overlay overlay, ILogger logger) : this()
+        public OverlayPage(string Tag, Overlay overlay) : this()
         {
             this.Tag = Tag;
             this.overlay = overlay;
             this.overlay.ControllerTriggerUpdated += Overlay_ControllerTriggerUpdated;
             this.overlay.TrackpadsTriggerUpdated += Overlay_TrackpadsTriggerUpdated;
-
-            this.logger = logger;
 
             // controller enabler
             ToyControllerRadio.IsEnabled = Properties.Settings.Default.OverlayControllerFisherPrice;
@@ -369,7 +365,7 @@ namespace HandheldCompanion.Views.Pages
             if (!Initialized)
                 return;
 
-            overlay.ModelViewPort.SetValue(RenderOptions.EdgeModeProperty, Toggle_RenderAA.IsOn ? EdgeMode.Unspecified: EdgeMode.Aliased);
+            overlay.ModelViewPort.SetValue(RenderOptions.EdgeModeProperty, Toggle_RenderAA.IsOn ? EdgeMode.Unspecified : EdgeMode.Aliased);
 
             // save settings
             Properties.Settings.Default.OverlayRenderAntialiasing = Toggle_RenderAA.IsOn;

--- a/HandheldCompanion/Views/Pages/ProfileSettingsMode0.xaml.cs
+++ b/HandheldCompanion/Views/Pages/ProfileSettingsMode0.xaml.cs
@@ -1,6 +1,5 @@
 using ControllerCommon;
 using ControllerService.Sensors;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Windows;
 using System.Windows.Controls;
@@ -15,7 +14,6 @@ namespace HandheldCompanion.Views.Pages
     /// </summary>
     public partial class ProfileSettingsMode0 : Page
     {
-        private ILogger logger;
         private Profile profileCurrent;
         private PipeClient pipeClient;
 
@@ -24,10 +22,9 @@ namespace HandheldCompanion.Views.Pages
             InitializeComponent();
         }
 
-        public ProfileSettingsMode0(string Tag, Profile profileCurrent, PipeClient pipeClient, ILogger logger) : this()
+        public ProfileSettingsMode0(string Tag, Profile profileCurrent, PipeClient pipeClient) : this()
         {
             this.Tag = Tag;
-            this.logger = logger;
 
             this.profileCurrent = profileCurrent;
             this.pipeClient = pipeClient;

--- a/HandheldCompanion/Views/Pages/ProfileSettingsMode1.xaml.cs
+++ b/HandheldCompanion/Views/Pages/ProfileSettingsMode1.xaml.cs
@@ -1,7 +1,6 @@
 ﻿using ControllerCommon;
 using LiveCharts;
 using LiveCharts.Defaults;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Windows;
 using System.Windows.Controls;
@@ -13,7 +12,6 @@ namespace HandheldCompanion.Views.Pages
     /// </summary>
     public partial class ProfileSettingsMode1 : Page
     {
-        private ILogger logger;
         private Profile profileCurrent;
         private PipeClient pipeClient;
 
@@ -34,10 +32,9 @@ namespace HandheldCompanion.Views.Pages
             lvLineSeriesDefault.Values = new ChartValues<double>() { 0, 1 };
         }
 
-        public ProfileSettingsMode1(string Tag, Profile profileCurrent, PipeClient pipeClient, ILogger logger) : this()
+        public ProfileSettingsMode1(string Tag, Profile profileCurrent, PipeClient pipeClient) : this()
         {
             this.Tag = Tag;
-            this.logger = logger;
 
             this.profileCurrent = profileCurrent;
             this.pipeClient = pipeClient;

--- a/HandheldCompanion/Views/Pages/ProfilesPage.xaml.cs
+++ b/HandheldCompanion/Views/Pages/ProfilesPage.xaml.cs
@@ -1,7 +1,6 @@
 using ControllerCommon;
 using ControllerCommon.Managers;
 using ControllerCommon.Utils;
-using Microsoft.Extensions.Logging;
 using Microsoft.Win32;
 using ModernWpf.Controls;
 using System;
@@ -22,7 +21,6 @@ namespace HandheldCompanion.Views.Pages
     public partial class ProfilesPage : Page
     {
         private MainWindow mainWindow;
-        private ILogger logger;
 
         private ProfileManager profileManager;
         private Profile profileCurrent;
@@ -37,12 +35,11 @@ namespace HandheldCompanion.Views.Pages
             InitializeComponent();
         }
 
-        public ProfilesPage(string Tag, MainWindow mainWindow, ILogger logger) : this()
+        public ProfilesPage(string Tag, MainWindow mainWindow) : this()
         {
             this.Tag = Tag;
 
             this.mainWindow = mainWindow;
-            this.logger = logger;
 
             this.pipeClient = mainWindow.pipeClient;
             this.pipeClient.ServerMessage += OnServerMessage;
@@ -253,7 +250,7 @@ namespace HandheldCompanion.Views.Pages
                             }
                             catch (Exception ex)
                             {
-                                logger.LogError(ex.Message, true);
+                                LogManager.LogError(ex.Message, true);
                             }
                             break;
                     }
@@ -290,7 +287,7 @@ namespace HandheldCompanion.Views.Pages
                 }
                 catch (Exception ex)
                 {
-                    logger.LogError(ex.Message);
+                    LogManager.LogError(ex.Message);
                 }
             }
         }
@@ -306,10 +303,10 @@ namespace HandheldCompanion.Views.Pages
                 default:
                 case Input.JoystickCamera:
                 case Input.PlayerSpace:
-                    page = new ProfileSettingsMode0("ProfileSettingsMode0", profileCurrent, pipeClient, logger);
+                    page = new ProfileSettingsMode0("ProfileSettingsMode0", profileCurrent, pipeClient);
                     break;
                 case Input.JoystickSteering:
-                    page = new ProfileSettingsMode1("ProfileSettingsMode1", profileCurrent, pipeClient, logger);
+                    page = new ProfileSettingsMode1("ProfileSettingsMode1", profileCurrent, pipeClient);
                     break;
             }
             mainWindow.NavView_Navigate(page);

--- a/HandheldCompanion/Views/Pages/SettingsPage.xaml.cs
+++ b/HandheldCompanion/Views/Pages/SettingsPage.xaml.cs
@@ -2,7 +2,6 @@ using ControllerCommon;
 using ControllerCommon.Managers;
 using ControllerCommon.Utils;
 using HandheldCompanion.Managers;
-using Microsoft.Extensions.Logging;
 using ModernWpf;
 using ModernWpf.Controls;
 using System;
@@ -25,7 +24,6 @@ namespace HandheldCompanion.Views.Pages
     public partial class SettingsPage : Page
     {
         private MainWindow mainWindow;
-        private ILogger logger;
         private PipeClient pipeClient;
         private ServiceManager serviceManager;
 
@@ -72,11 +70,10 @@ namespace HandheldCompanion.Views.Pages
             updateManager.Updated += UpdateManager_Updated;
         }
 
-        public SettingsPage(string Tag, MainWindow mainWindow, ILogger logger) : this()
+        public SettingsPage(string Tag, MainWindow mainWindow) : this()
         {
             this.Tag = Tag;
             this.mainWindow = mainWindow;
-            this.logger = logger;
 
             this.pipeClient = mainWindow.pipeClient;
             this.pipeClient.ServerMessage += OnServerMessage;

--- a/HandheldCompanion/Views/Windows/Overlay.xaml.cs
+++ b/HandheldCompanion/Views/Windows/Overlay.xaml.cs
@@ -1,9 +1,7 @@
 using ControllerCommon;
 using ControllerCommon.Utils;
-using Microsoft.Extensions.Logging;
 using SharpDX.XInput;
 using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows;
@@ -32,7 +30,6 @@ namespace HandheldCompanion.Views.Windows
         public static extern int GetWindowLong(IntPtr hWnd, int nIndex);
         #endregion
 
-        private ILogger logger;
         private PipeClient pipeClient;
 
         private Model CurrentModel;
@@ -103,10 +100,8 @@ namespace HandheldCompanion.Views.Windows
             this.SourceInitialized += Overlay_SourceInitialized;
         }
 
-        public Overlay(ILogger logger, PipeClient pipeClient) : this()
+        public Overlay(PipeClient pipeClient) : this()
         {
-            this.logger = logger;
-
             this.pipeClient = pipeClient;
             this.pipeClient.ServerMessage += OnServerMessage;
         }
@@ -644,7 +639,7 @@ namespace HandheldCompanion.Views.Windows
             return new DiffuseMaterial(new SolidColorBrush(TransitionColor));
         }
 
-        private void UpwardVisibilityRotationShoulderButtons(float ShoulderButtonsAngleDeg, 
+        private void UpwardVisibilityRotationShoulderButtons(float ShoulderButtonsAngleDeg,
                                                              Vector3D UpwardVisibilityRotationAxis,
                                                              Vector3D UpwardVisibilityRotationPoint,
                                                              float ShoulderTriggerAngleDeg,

--- a/HandheldCompanion/models/ModelToyController.cs
+++ b/HandheldCompanion/models/ModelToyController.cs
@@ -29,7 +29,7 @@ namespace HandheldCompanion.Models
         Model3DGroup YLetter;
         Model3DGroup YLetterInside1;
         Model3DGroup YLetterInside2;
-            
+
         Model3DGroup DPadLeft1;
         Model3DGroup DPadUp2;
         Model3DGroup DPadRight3;
@@ -87,7 +87,7 @@ namespace HandheldCompanion.Models
             Smile4 = modelImporter.Load($"models/{ModelName}/Smile4.obj");
             Smile5 = modelImporter.Load($"models/{ModelName}/Smile5.obj");
             Smile6 = modelImporter.Load($"models/{ModelName}/Smile6.obj");
-            
+
             ALetter = modelImporter.Load($"models/{ModelName}/ALetter.obj");
             ALetterInside = modelImporter.Load($"models/{ModelName}/ALetterInside.obj");
             BLetter = modelImporter.Load($"models/{ModelName}/BLetter.obj");
@@ -223,7 +223,7 @@ namespace HandheldCompanion.Models
                 DefaultMaterials[model3D] = MaterialPlasticBlack;
 
                 // specific material(s)
-                if (model3D == MainBody || model3D == Smile1 || model3D == Smile2 
+                if (model3D == MainBody || model3D == Smile1 || model3D == Smile2
                     || model3D == DPadLeft1 || model3D == DPadUp2 || model3D == DPadRight3 || model3D == DPadDown4
                     || model3D == ALetter || model3D == BLetter || model3D == XLetter || model3D == YLetter
                     )
@@ -246,7 +246,7 @@ namespace HandheldCompanion.Models
                 }
 
 
-                if (model3D == JoystickLeftCover || model3D == JoystickRightCover 
+                if (model3D == JoystickLeftCover || model3D == JoystickRightCover
                     || model3D == LeftThumbRing || model3D == RightThumbRing
                     || model3D == YLetterInside1 || model3D == YLetterInside2)
                 {


### PR DESCRIPTION
This pull request aims at lowering the overall CPU usage from the LogTrace calls we had. Even though default logger settings excluded LogTrace calls, they were still affecting ControllerService CPU usage by about 10%.

Switching to a single static LogManager object also makes it way easier to handle logging.