### PR TITLE
Fix OneXPlayer Mini AMD Keyboard key combination

### DIFF
--- a/ControllerCommon/Devices/OneXPlayerMiniAMD.cs
+++ b/ControllerCommon/Devices/OneXPlayerMiniAMD.cs
@@ -32,7 +32,7 @@ namespace ControllerCommon.Devices
                 { 'Z', 'Y' },
             };
 
-            listeners.Add(new DeviceChord("Keyboard key", new List<KeyCode>() { KeyCode.LWin, KeyCode.RControlKey, KeyCode.O }));
+            listeners.Add(new DeviceChord("Keyboard key", new List<KeyCode>() { KeyCode.RControlKey, KeyCode.LWin, KeyCode.O, KeyCode.LWin, KeyCode.O }));
             listeners.Add(new DeviceChord("Function key", new List<KeyCode>() { KeyCode.LWin, KeyCode.D }));
             listeners.Add(new DeviceChord("Function + Volume Up", new List<KeyCode>() { KeyCode.F1 }));
 


### PR DESCRIPTION
Figured it out with an owner of a device that the keyboard button was not working, tool output:

![image](https://user-images.githubusercontent.com/14330834/182316226-dd820720-67a8-46af-a697-df20a7b5ce19.png)
![image](https://user-images.githubusercontent.com/14330834/182316287-2f08f1b3-14c4-40a5-bbe2-19bf60703b36.png)
